### PR TITLE
Remove 'closed' class toggling

### DIFF
--- a/script.js
+++ b/script.js
@@ -4,11 +4,9 @@ const topicElList = document.querySelectorAll('.topic-container');
 for (const topicEl of topicElList) {
   topicEl.addEventListener('click', () => {
     if (topicEl.classList.contains('open')) {
-      topicEl.classList.toggle('closed');
       topicEl.classList.toggle('open');
     } else {
       removeClasses();
-      topicEl.classList.toggle('closed');
       topicEl.classList.toggle('open');
     }
   });
@@ -17,6 +15,5 @@ for (const topicEl of topicElList) {
 function removeClasses() {
   topicElList.forEach((topicEl) => {
     topicEl.classList.remove('open');
-    topicEl.classList.add('closed');
   });
 }


### PR DESCRIPTION
Remove 'closed' class toggling from JS script, since the state management is done by 'open' class only.